### PR TITLE
Fix: Corregir redirección post-login en admin para usar parámetro 'next'

### DIFF
--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -1,29 +1,55 @@
 import LoginForm from '@/components/admin/LoginForm';
 import React from 'react';
-
-// Las importaciones para Supabase, redirect y headers están intencionalmente comentadas
-// para el paso actual de diagnóstico.
-// import { createSupabaseServerClient } from '@/lib/supabase/server';
-// import { redirect } from 'next/navigation';
-// import { headers } from 'next/headers';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { redirect } from 'next/navigation';
+// cookies ya no es necesario importarlo aquí directamente si createSupabaseServerClient lo maneja
 
 export const dynamic = 'force-dynamic';
 
+// Definición simple de UserRole para esta página, o podría importarse si está centralizada
+type UserRole = 'administrador' | 'referidor';
+
 export default async function LoginPage() {
-  // Toda la lógica de obtención de pathname y sesión está comentada para el diagnóstico.
-  // console.log("LoginPage Diag: Renderizando LoginForm...");
-  // const headerList = headers();
-  // const pathname = headerList.get('x-next-pathname') || headerList.get('next-url') || '';
+  // createSupabaseServerClient obtiene cookies internamente
+  const supabase = createSupabaseServerClient();
 
-  // const supabase = createSupabaseServerClient();
-  // const { data: { session } } = await supabase.auth.getSession();
+  const { data: { session }, error: sessionError } = await supabase.auth.getSession();
 
-  // if (session) {
-  //   console.log("LoginPage Diag: Sesión encontrada, intentando redirigir (comentado)");
-  //   // redirect('/admin/dashboard');
-  // } else {
-  //   console.log("LoginPage Diag: No se encontró sesión.");
-  // }
+  if (sessionError) {
+    console.error("LoginPage: Error al obtener la sesión:", sessionError.message);
+    // Continuar para mostrar el formulario de login si hay error de sesión
+  }
 
+  if (session) {
+    // Verificar si el usuario es administrador.
+    // El middleware ya hace esto, pero aquí es una doble verificación
+    // o para el caso en que el middleware no haya redirigido aún.
+    const { data: userProfile, error: profileError } = await supabase
+      .from('usuarios')
+      .select('rol')
+      .eq('id', session.user.id)
+      .single<{ rol: UserRole | null }>();
+
+    if (profileError) {
+      console.warn("LoginPage: Error al obtener el perfil del usuario:", profileError.message);
+      // Si hay error de perfil pero hay sesión, es ambiguo.
+      // Podríamos dejar que el middleware maneje la redirección final,
+      // o redirigir a dashboard como un intento.
+      // Por ahora, si es admin, redirigimos.
+    }
+
+    if (userProfile?.rol === 'administrador') {
+      // Si el usuario ya tiene una sesión activa y es administrador,
+      // redirigirlo al dashboard. El middleware también tiene una lógica similar.
+      console.log("LoginPage: Sesión de administrador activa encontrada, redirigiendo a /admin/dashboard.");
+      redirect('/admin/dashboard');
+    }
+    // Si tiene sesión pero no es admin, o el rol es nulo/desconocido,
+    // se mostrará el formulario de login. El middleware se encargará de denegar acceso
+    // a otras rutas de admin si intenta navegar a ellas.
+  }
+
+  // Si no hay sesión, o si la sesión no es de un administrador (y no fue redirigido),
+  // se renderiza el LoginForm.
   return <LoginForm />;
 }


### PR DESCRIPTION
- Modificado LoginForm.tsx para leer el parámetro 'next' de la URL y redirigir a dicha URL si es una ruta de admin válida. Si no, redirige a /admin/dashboard.
- Se ajustó el orden de router.push y router.refresh para evitar conflictos con la redirección del middleware desde /admin/login.
- Reactivada y corregida la lógica en app/admin/login/page.tsx para redirigir a los administradores ya autenticados al dashboard desde el lado del servidor, mejorando la UX y añadiendo una capa de seguridad.